### PR TITLE
Output script to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 Creates a T-SQL script to build a table with all supported SQL Server versions and their support dates
 
 # Usage
-Download the latest release and run the exe or run `dotnet GetSqlServerVersionInfo.dll` depending on your system (see the Release tab for info).
+Download the [latest release](https://github.com/jadarnel27/SqlServerVersionScript/releases).  There are two versions of the application:
 
-This is a Windows console app.  To build and run the source code yourself, open the solution in Visual Studio, and press F5 to run the app under the debugger.
+ - **SqlServerVersionScript-NetCoreSC-win64.zip**
+     - a self-contained .NET Core app (.exe) that runs on 64-bit Windows
+     - run this by extracting the zip and running GetSqlServerVersionInfo.exe
+ - **SqlServerVersionScript-NetCoreFDD-win64.zip**
+     - a (much smaller) Framework-dependent deployment of the .NET Core app (.dll) that run on 64-bit Windows
+     - requires .NET Core to be present on the machine
+     - this can be run from the command line by extracting the zip and running `dotnet GetSqlServerVersionInfo.dll`
+	 
+By default, a file named SqlServerVersions.sql will be created in the same directory where you ran the application.  To specify a destination folder, pass the path as a command line argument:
 
-A Command Prompt window will be displayed with the T-SQL script.  You can then copy the contents of the script out of the console window and run it or save it.
+    GetSqlServerVersionInfo.exe "C:\Temp"
+	// or
+	dotnet GetSqlServerVersionInfo.dll "C:\Temp"
 
 # Example script
 See the \src\SqlServerVersions-2018-05-22.sql in this repository for an example of the output of the application.

--- a/src/GetSqlServerVersionInfo/Program.cs
+++ b/src/GetSqlServerVersionInfo/Program.cs
@@ -1,6 +1,7 @@
 ﻿using HtmlAgilityPack;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -11,12 +12,44 @@ namespace GetSqlServerVersionInfo
     {
         public static void Main(string[] args)
         {
+            try
+            {
+                TryMain(args);
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine("An error occurred.  Details to follow:");
+                Console.WriteLine();
+                Console.WriteLine(e);
+            }
+            finally
+            {
+                Console.ReadLine();
+            }
+        }
+
+        private static void TryMain(string[] args)
+        {
             var supportDates = GetSqlServerSupportDatesFromMicrosoftWebsite();
             var builds = GetSqlServerBuildsFromMicrosoftWebsite(supportDates);
             var sqlScript = BuildSqlScript(builds);
 
-            Console.WriteLine(sqlScript);
-            Console.ReadLine();
+            var file = GetDestinationFileFromCommandLineArguments(args);
+            File.WriteAllText(file.FullName, sqlScript);
+
+            Console.WriteLine($"SqlServerVersions.sql was saved to {file.FullName}");
+        }
+
+        private static FileInfo GetDestinationFileFromCommandLineArguments(string[] args)
+        {
+            var destinationPathArgument =
+                args.Length < 1 || string.IsNullOrWhiteSpace(args[0])
+                    ? @".\"
+                    : args[0];
+            var destinationPath = Path.Combine(destinationPathArgument,
+                "SqlServerVersions.sql");
+
+            return new FileInfo(destinationPath);
         }
 
         private static List<SqlServerSupportDates> GetSqlServerSupportDatesFromMicrosoftWebsite()


### PR DESCRIPTION
Closes #1 

Saves the script to a .sql file instead of just printing it to the console window.

Also adds option for setting a destination path.